### PR TITLE
`Experiment` Modernize NPM package. Introduce tests with tagged template literals, validator functions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "js-sandbox",
       "version": "1.0.21",
       "license": "ISC",
+      "dependencies": {
+        "quickjs-emscripten": "^0.23.0"
+      },
       "devDependencies": {
         "@types/node": "^20.6.0",
         "@vitest/coverage-v8": "^0.34.4",
@@ -22,8 +25,7 @@
       },
       "peerDependencies": {
         "acorn": "^8.10.0",
-        "acorn-walk": "^8.2.0",
-        "quickjs-emscripten": "^0.23.0"
+        "acorn-walk": "^8.2.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1350,8 +1352,7 @@
     "node_modules/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmmirror.com/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-CIP+NDRYDDqbT3cTiN8Bon1wsZ7IgISVYCJHYsPc86oxszpepVMPXFfttyQgn1u1okg1HPnCnM7Xv1LrCO/VmQ==",
-      "peer": true
+      "integrity": "sha512-CIP+NDRYDDqbT3cTiN8Bon1wsZ7IgISVYCJHYsPc86oxszpepVMPXFfttyQgn1u1okg1HPnCnM7Xv1LrCO/VmQ=="
     },
     "node_modules/react-is": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joehecn/js-sandbox.git"
+    "url": "git+https://github.com/SellerCloudTeam/js-sandbox.git"
   },
   "keywords": [
     "javascript",
@@ -28,9 +28,9 @@
   "author": "leanbrown@live.cn",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/joehecn/js-sandbox/issues"
+    "url": "https://github.com/SellerCloudTeam/js-sandbox/issues"
   },
-  "homepage": "https://github.com/joehecn/js-sandbox#readme",
+  "homepage": "https://github.com/SellerCloudTeam/js-sandbox#readme",
   "files": [
     "lib/**/*"
   ],

--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
   "files": [
     "lib/**/*"
   ],
+  "dependencies": {
+    "quickjs-emscripten": "^0.23.0"
+  },
   "devDependencies": {
     "@types/node": "^20.6.0",
     "@vitest/coverage-v8": "^0.34.4",
@@ -48,7 +51,6 @@
   },
   "peerDependencies": {
     "acorn": "^8.10.0",
-    "acorn-walk": "^8.2.0",
-    "quickjs-emscripten": "^0.23.0"
+    "acorn-walk": "^8.2.0"
   }
 }

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -1,0 +1,69 @@
+// npm run test src/__tests__/sellercloud.spec.ts
+
+import { describe, it, expect } from 'vitest';
+
+import JsSandbox, { CustomFunction } from '../index';
+
+import { rackLevel } from './sellercloud/utils';
+import { primitivesOnlyValidator } from './sellercloud/validators';
+
+const prepCustomFunctions = (funcs: Record<string, Function>, mainFunction: CustomFunction) => {
+  const whitelistedFunctions: CustomFunction[] = Object.entries(funcs).map<CustomFunction>(([name, func]) => ({
+    functionName: name,
+    arrowSandboxFunctionStr: func.toString(),
+  }));
+
+  return [...whitelistedFunctions, mainFunction];
+};
+
+describe('javascript tagged template literal', () => {
+  it('should be ok', async () => {
+    const fun = ``;
+
+    const tag = `primitivesOnlyValidator`;
+    const partial = `(context)(input)`;
+    const expression = '`${rackLevel}`';
+    // const expression = '`${{}}}`';
+    // const expression = '`abcd`';
+
+    const code = `${tag}${partial}${expression}`;
+    // const code = `fetch("http://google.com")`;
+
+    // const code = `input`;
+
+    const option = { context: { rack: { levels: 2, columns: 5 } }, input: 'input-text' };
+
+    const funcs = {
+      rackLevel,
+      primitivesOnlyValidator,
+    };
+
+    const mainFunction: CustomFunction = {
+      functionName: 'main',
+      arrowSandboxFunctionStr: `({ context, input }) => ${code}`,
+    };
+
+    const customFunctions = prepCustomFunctions(funcs, mainFunction);
+
+    // console.log(customFunctions[1].arrowGlobalFunction);
+    // console.log(customFunctions[1].arrowGlobalFunction.toString());
+    // console.log(customFunctions[2].functionName);
+    // console.log(customFunctions[2].arrowSandboxFunctionStr);
+
+    const expected = 'abcd';
+
+    // Set a prop at the global level of the CALLER context
+    // TODO: Try to read this from the SANDBOX?
+    global['abcdefg'] = 'abcdefg';
+
+    const jsSandbox = new JsSandbox({
+      entry: mainFunction.functionName,
+      customFunctions,
+    });
+
+    const result = await jsSandbox.runCodeSafe(fun, option);
+    console.log('---- result');
+    console.log(result);
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -23,7 +23,10 @@ describe('javascript tagged template literal', () => {
 
     // const code = `input`;
 
-    const option = { context: { rack: { levels: 2, columns: 5 } }, input: 'input-text' };
+    const context = { rack: { levels: 2, columns: 5 } };
+    const input = 'input-text';
+
+    const option = { context, input };
 
     const funcs = {
       rackLevel,

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -33,7 +33,9 @@ describe('javascript tagged template literal', () => {
 
     // const code = `input`;
 
-    const expected = BIN_POSITION_12_EXPECTED;
+    // NOTE: Expectation should be stringified because
+    //       The test expression to be evaluated is one of string interpolation
+    const expected = `${BIN_POSITION_12_EXPECTED}`;
 
     const context = NAMING_CONVENTION_CONTEXT;
     const input = BIN_NAME_WITH_POSITION_12;

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -5,11 +5,13 @@ import { describe, it, expect } from 'vitest';
 import JsSandbox from '../index';
 import { prepCustomFunctions, prepMainFunction } from './sellercloud/infra';
 
+import { HackContext } from './sellercloud/types';
+
 import { rackLevel, numericOnly } from './sellercloud/utils';
 import { primitivesOnlyValidator } from './sellercloud/validators';
 
 // e.g. a Rack 2 levels high, 5 columns wide
-const NAMING_CONVENTION_CONTEXT = {
+const NAMING_CONVENTION_CONTEXT: HackContext = {
   rack: {
     levels: 2,
     columns: 5,

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -9,9 +9,7 @@ import { rackLevel } from './sellercloud/utils';
 import { primitivesOnlyValidator } from './sellercloud/validators';
 
 describe('javascript tagged template literal', () => {
-  it('should be ok', async () => {
-    const fun = ``;
-
+  it('should be executed ok', async () => {
     const tag = `primitivesOnlyValidator`;
     const partial = `(context)(input)`;
     const expression = '`${rackLevel}`';
@@ -40,11 +38,6 @@ describe('javascript tagged template literal', () => {
 
     const customFunctions = prepCustomFunctions(funcs, mainFunction);
 
-    // console.log(customFunctions[1].arrowGlobalFunction);
-    // console.log(customFunctions[1].arrowGlobalFunction.toString());
-    // console.log(customFunctions[2].functionName);
-    // console.log(customFunctions[2].arrowSandboxFunctionStr);
-
     const expected = 'abcd';
 
     // Set a prop at the global level of the CALLER context
@@ -56,7 +49,9 @@ describe('javascript tagged template literal', () => {
       customFunctions,
     });
 
+    const fun = ``;
     const result = await jsSandbox.runCodeSafe(fun, option);
+
     console.log('---- result');
     console.log(result);
     expect(result).toEqual(expected);

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -7,8 +7,8 @@ import { prepCustomFunctions, prepMainFunction } from './sellercloud/infra';
 
 import { HackContext } from './sellercloud/types';
 
-import { rackLevel, numericOnly } from './sellercloud/utils';
-import { primitivesOnlyValidator } from './sellercloud/validators';
+import { WHITELIST_ALL_UTILS } from './sellercloud/utils';
+import { WHITELIST_ALL_VALIDATORS } from './sellercloud/validators';
 
 // e.g. a Rack 2 levels high, 5 columns wide
 const NAMING_CONVENTION_CONTEXT: HackContext = {
@@ -42,22 +42,15 @@ describe('javascript tagged template literal', () => {
     const context = NAMING_CONVENTION_CONTEXT;
     const input = BIN_NAME_WITH_POSITION_12;
 
+    // Wrap our pieces of contexts & allowed functions into the JsSandbox concepts
     const option = { context, input };
 
-    const utils = {
-      rackLevel,
-      numericOnly,
-    };
-
-    const validators = {
-      primitivesOnlyValidator,
-    };
-
     const funcs = {
-      ...utils,
-      ...validators,
+      ...WHITELIST_ALL_UTILS,
+      ...WHITELIST_ALL_VALIDATORS,
     };
 
+    // Convert our allowed functions into JsSandbox `CustomFunction` function definitions
     const mainFunction = prepMainFunction(code);
     const customFunctions = prepCustomFunctions(funcs, mainFunction);
 

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -3,18 +3,10 @@
 import { describe, it, expect } from 'vitest';
 
 import JsSandbox, { CustomFunction } from '../index';
+import { prepCustomFunctions } from './sellercloud/infra';
 
 import { rackLevel } from './sellercloud/utils';
 import { primitivesOnlyValidator } from './sellercloud/validators';
-
-const prepCustomFunctions = (funcs: Record<string, Function>, mainFunction: CustomFunction) => {
-  const whitelistedFunctions: CustomFunction[] = Object.entries(funcs).map<CustomFunction>(([name, func]) => ({
-    functionName: name,
-    arrowSandboxFunctionStr: func.toString(),
-  }));
-
-  return [...whitelistedFunctions, mainFunction];
-};
 
 describe('javascript tagged template literal', () => {
   it('should be ok', async () => {

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -2,17 +2,29 @@
 
 import { describe, it, expect } from 'vitest';
 
-import JsSandbox, { CustomFunction } from '../index';
-import { prepCustomFunctions } from './sellercloud/infra';
+import JsSandbox from '../index';
+import { prepCustomFunctions, prepMainFunction } from './sellercloud/infra';
 
-import { rackLevel } from './sellercloud/utils';
+import { rackLevel, numericOnly } from './sellercloud/utils';
 import { primitivesOnlyValidator } from './sellercloud/validators';
+
+// e.g. a Rack 2 levels high, 5 columns wide
+const NAMING_CONVENTION_CONTEXT = {
+  rack: {
+    levels: 2,
+    columns: 5,
+  },
+};
+
+// e.g. Bin # 12 on a shelf
+const BIN_NAME_WITH_POSITION_12 = 'P012';
+const BIN_POSITION_12_EXPECTED = 12;
 
 describe('javascript tagged template literal', () => {
   it('should be executed ok', async () => {
     const tag = `primitivesOnlyValidator`;
     const partial = `(context)(input)`;
-    const expression = '`${rackLevel}`';
+    const expression = '`${numericOnly}`';
     // const expression = '`${{}}}`';
     // const expression = '`abcd`';
 
@@ -21,24 +33,29 @@ describe('javascript tagged template literal', () => {
 
     // const code = `input`;
 
-    const context = { rack: { levels: 2, columns: 5 } };
-    const input = 'input-text';
+    const expected = BIN_POSITION_12_EXPECTED;
+
+    const context = NAMING_CONVENTION_CONTEXT;
+    const input = BIN_NAME_WITH_POSITION_12;
 
     const option = { context, input };
 
-    const funcs = {
+    const utils = {
       rackLevel,
+      numericOnly,
+    };
+
+    const validators = {
       primitivesOnlyValidator,
     };
 
-    const mainFunction: CustomFunction = {
-      functionName: 'main',
-      arrowSandboxFunctionStr: `({ context, input }) => ${code}`,
+    const funcs = {
+      ...utils,
+      ...validators,
     };
 
+    const mainFunction = prepMainFunction(code);
     const customFunctions = prepCustomFunctions(funcs, mainFunction);
-
-    const expected = 'abcd';
 
     // Set a prop at the global level of the CALLER context
     // TODO: Try to read this from the SANDBOX?

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -130,6 +130,38 @@ describe('javascript tagged template literal', () => {
     await expect(promise).rejects.toThrowError();
   });
 
+  it('should allow inline primitives', async () => {
+    const tag = `primitivesOnlyValidator`;
+    const partial = `(context)(input)`;
+    const expression = '`${"sample-inline-primitive"}`';
+
+    const code = `${tag}${partial}${expression}`;
+
+    const expected = `sample-inline-primitive`;
+
+    // Wrap our pieces of context & input + allowed functions into the JsSandbox concepts
+    const option = {};
+
+    const funcs = {
+      ...WHITELIST_ALL_UTILS,
+      ...WHITELIST_ALL_VALIDATORS,
+    };
+
+    // Convert our allowed functions into JsSandbox `CustomFunction` function definitions
+    const mainFunction = prepMainFunction(code);
+    const customFunctions = prepCustomFunctions(funcs, mainFunction);
+
+    const jsSandbox = new JsSandbox({
+      entry: mainFunction.functionName,
+      customFunctions,
+    });
+
+    const fun = ``;
+    const result = await jsSandbox.runCodeSafe(fun, option);
+
+    expect(result).toEqual(expected);
+  });
+
   it('should allow referenced primitives', async () => {
     const tag = `primitivesOnlyValidator`;
     const partial = `(context)(input)`;

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -70,4 +70,24 @@ describe('javascript tagged template literal', () => {
     console.log(result);
     expect(result).toEqual(expected);
   });
+
+  it('should not allow fetch', async () => {
+    const tag = `primitivesOnlyValidator`;
+    const partial = `(context)(input)`;
+    const expression = '`${fetch("http://google.com")}`';
+
+    const code = `${tag}${partial}${expression}`;
+
+    // Prepare the main function as a JsSandbox `CustomFunction` function definition
+    const mainFunction = prepMainFunction(code);
+
+    const jsSandbox = new JsSandbox({
+      entry: mainFunction.functionName,
+    });
+
+    const fun = ``;
+    const promise = jsSandbox.runCodeSafe(fun, {});
+
+    await expect(promise).rejects.toThrowError();
+  });
 });

--- a/src/__tests__/sellercloud.spec.ts
+++ b/src/__tests__/sellercloud.spec.ts
@@ -77,15 +77,25 @@ describe('javascript tagged template literal', () => {
 
     const code = `${tag}${partial}${expression}`;
 
-    // Prepare the main function as a JsSandbox `CustomFunction` function definition
+    // Wrap our pieces of context & input + allowed functions into the JsSandbox concepts
+    const option = {};
+
+    const funcs = {
+      ...WHITELIST_ALL_UTILS,
+      ...WHITELIST_ALL_VALIDATORS,
+    };
+
+    // Convert our allowed functions into JsSandbox `CustomFunction` function definitions
     const mainFunction = prepMainFunction(code);
+    const customFunctions = prepCustomFunctions(funcs, mainFunction);
 
     const jsSandbox = new JsSandbox({
       entry: mainFunction.functionName,
+      customFunctions,
     });
 
     const fun = ``;
-    const promise = jsSandbox.runCodeSafe(fun, {});
+    const promise = jsSandbox.runCodeSafe(fun, option);
 
     await expect(promise).rejects.toThrowError();
   });
@@ -97,15 +107,25 @@ describe('javascript tagged template literal', () => {
 
     const code = `${tag}${partial}${expression}`;
 
-    // Prepare the main function as a JsSandbox `CustomFunction` function definition
+    // Wrap our pieces of context & input + allowed functions into the JsSandbox concepts
+    const option = {};
+
+    const funcs = {
+      ...WHITELIST_ALL_UTILS,
+      ...WHITELIST_ALL_VALIDATORS,
+    };
+
+    // Convert our allowed functions into JsSandbox `CustomFunction` function definitions
     const mainFunction = prepMainFunction(code);
+    const customFunctions = prepCustomFunctions(funcs, mainFunction);
 
     const jsSandbox = new JsSandbox({
       entry: mainFunction.functionName,
+      customFunctions,
     });
 
     const fun = ``;
-    const promise = jsSandbox.runCodeSafe(fun, {});
+    const promise = jsSandbox.runCodeSafe(fun, option);
 
     await expect(promise).rejects.toThrowError();
   });
@@ -117,15 +137,59 @@ describe('javascript tagged template literal', () => {
 
     const code = `${tag}${partial}${expression}`;
 
-    // Prepare the main function as a JsSandbox `CustomFunction` function definition
+    // Our pieces of context & input
+    const context = NAMING_CONVENTION_CONTEXT;
+    const input = BIN_NAME_WITH_POSITION_12;
+
+    // Wrap our pieces of context & input + allowed functions into the JsSandbox concepts
+    const option = { context, input };
+
+    const funcs = {
+      ...WHITELIST_ALL_UTILS,
+      ...WHITELIST_ALL_VALIDATORS,
+    };
+
+    // Convert our allowed functions into JsSandbox `CustomFunction` function definitions
     const mainFunction = prepMainFunction(code);
+    const customFunctions = prepCustomFunctions(funcs, mainFunction);
 
     const jsSandbox = new JsSandbox({
       entry: mainFunction.functionName,
+      customFunctions,
     });
 
     const fun = ``;
-    const promise = jsSandbox.runCodeSafe(fun, {});
+    const promise = jsSandbox.runCodeSafe(fun, option);
+
+    await expect(promise).rejects.toThrowError();
+  });
+
+  it('should not allow inline functions', async () => {
+    const tag = `primitivesOnlyValidator`;
+    const partial = `(context)(input)`;
+    const expression = '`${(function abc() { return "abc-output"; })}`';
+
+    const code = `${tag}${partial}${expression}`;
+
+    // Wrap our pieces of context & input + allowed functions into the JsSandbox concepts
+    const option = {};
+
+    const funcs = {
+      ...WHITELIST_ALL_UTILS,
+      ...WHITELIST_ALL_VALIDATORS,
+    };
+
+    // Convert our allowed functions into JsSandbox `CustomFunction` function definitions
+    const mainFunction = prepMainFunction(code);
+    const customFunctions = prepCustomFunctions(funcs, mainFunction);
+
+    const jsSandbox = new JsSandbox({
+      entry: mainFunction.functionName,
+      customFunctions,
+    });
+
+    const fun = ``;
+    const promise = jsSandbox.runCodeSafe(fun, option);
 
     await expect(promise).rejects.toThrowError();
   });

--- a/src/__tests__/sellercloud/infra/index.ts
+++ b/src/__tests__/sellercloud/infra/index.ts
@@ -1,1 +1,2 @@
 export * from './prep-custom-functions';
+export * from './prep-main-function';

--- a/src/__tests__/sellercloud/infra/index.ts
+++ b/src/__tests__/sellercloud/infra/index.ts
@@ -1,0 +1,1 @@
+export * from './prep-custom-functions';

--- a/src/__tests__/sellercloud/infra/prep-custom-functions.ts
+++ b/src/__tests__/sellercloud/infra/prep-custom-functions.ts
@@ -1,0 +1,10 @@
+import { CustomFunction } from '../../..';
+
+export const prepCustomFunctions = (funcs: Record<string, Function>, mainFunction: CustomFunction) => {
+  const whitelistedFunctions: CustomFunction[] = Object.entries(funcs).map<CustomFunction>(([name, func]) => ({
+    functionName: name,
+    arrowSandboxFunctionStr: func.toString(),
+  }));
+
+  return [...whitelistedFunctions, mainFunction];
+};

--- a/src/__tests__/sellercloud/infra/prep-main-function.ts
+++ b/src/__tests__/sellercloud/infra/prep-main-function.ts
@@ -1,0 +1,6 @@
+import { CustomFunction } from '../../..';
+
+export const prepMainFunction = (code: string): CustomFunction => ({
+  functionName: 'main',
+  arrowSandboxFunctionStr: `({ context, input }) => ${code}`,
+});

--- a/src/__tests__/sellercloud/types/hack-context.ts
+++ b/src/__tests__/sellercloud/types/hack-context.ts
@@ -1,0 +1,5 @@
+import { RackMeta } from './rack-meta';
+
+export type HackContext = {
+  rack: RackMeta;
+};

--- a/src/__tests__/sellercloud/types/index.ts
+++ b/src/__tests__/sellercloud/types/index.ts
@@ -1,0 +1,2 @@
+export * from './hack-context';
+export * from './rack-meta';

--- a/src/__tests__/sellercloud/types/rack-meta.ts
+++ b/src/__tests__/sellercloud/types/rack-meta.ts
@@ -1,0 +1,4 @@
+export type RackMeta = {
+  columns: number;
+  levels: number;
+};

--- a/src/__tests__/sellercloud/utils/index.ts
+++ b/src/__tests__/sellercloud/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './rack-level';
+export * from './string';

--- a/src/__tests__/sellercloud/utils/index.ts
+++ b/src/__tests__/sellercloud/utils/index.ts
@@ -1,2 +1,2 @@
-export * from './rack-level';
+export * from './rack';
 export * from './string';

--- a/src/__tests__/sellercloud/utils/index.ts
+++ b/src/__tests__/sellercloud/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './rack';
 export * from './string';
+export * from './whitelists';

--- a/src/__tests__/sellercloud/utils/index.ts
+++ b/src/__tests__/sellercloud/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './rack-level';

--- a/src/__tests__/sellercloud/utils/rack-level.ts
+++ b/src/__tests__/sellercloud/utils/rack-level.ts
@@ -1,1 +1,0 @@
-export const rackLevel = (context) => (input) => 'LEVEL-TODO';

--- a/src/__tests__/sellercloud/utils/rack-level.ts
+++ b/src/__tests__/sellercloud/utils/rack-level.ts
@@ -1,0 +1,1 @@
+export const rackLevel = (context) => (input) => 'LEVEL-TODO';

--- a/src/__tests__/sellercloud/utils/rack.ts
+++ b/src/__tests__/sellercloud/utils/rack.ts
@@ -1,0 +1,3 @@
+import { HackContext } from '../types';
+
+export const rackLevel = (context: HackContext) => (input: string) => 'LEVEL-TODO';

--- a/src/__tests__/sellercloud/utils/rack.ts
+++ b/src/__tests__/sellercloud/utils/rack.ts
@@ -1,3 +1,30 @@
 import { HackContext } from '../types';
+import { numericOnly } from './string';
 
-export const rackLevel = (context: HackContext) => (input: string) => 'LEVEL-TODO';
+export const rackNumber = (context: HackContext) => (source: string) => {
+  const number = numericOnly(context)(source);
+
+  const binsInRack = context.rack.columns * context.rack.levels;
+  const rack = Math.ceil(number / binsInRack);
+
+  return rack;
+};
+
+export const levelNumber = (context: HackContext) => (source: string) => {
+  const ordinal = ordinalNumberInRack(context)(source);
+
+  const level = Math.ceil(ordinal / context.rack.columns);
+
+  return level;
+};
+
+const ordinalNumberInRack = (context: HackContext) => (source: string) => {
+  const number = numericOnly(context)(source);
+
+  const binsInRack = context.rack.columns * context.rack.levels;
+
+  // e.g. bin 7 becomes # 3 in a 4-bin rack scenario
+  const ordinal = ((number - 1) % binsInRack) + 1;
+
+  return ordinal;
+};

--- a/src/__tests__/sellercloud/utils/string.ts
+++ b/src/__tests__/sellercloud/utils/string.ts
@@ -1,0 +1,14 @@
+type HackContext = {}; // Dummy
+
+export const stringify =
+  (context: HackContext) =>
+  <T>(value: T) =>
+    String(value);
+
+export const numericOnly = (context: HackContext) => (value: string) => +(value.match(/\d+/)?.[0] ?? 0);
+
+export const padStartZeroes =
+  (digits: number) =>
+  (context: HackContext) =>
+  <T>(value: T) =>
+    String(value).padStart(digits, '0');

--- a/src/__tests__/sellercloud/utils/string.ts
+++ b/src/__tests__/sellercloud/utils/string.ts
@@ -1,4 +1,4 @@
-type HackContext = {}; // Dummy
+import { HackContext } from '../types';
 
 export const stringify =
   (context: HackContext) =>

--- a/src/__tests__/sellercloud/utils/whitelists.ts
+++ b/src/__tests__/sellercloud/utils/whitelists.ts
@@ -1,0 +1,19 @@
+import { levelNumber, rackNumber } from './rack';
+
+import { numericOnly, padStartZeroes, stringify } from './string';
+
+export const WHITELIST_LOCATION_TERMS_UTILS = {
+  rackNumber,
+  levelNumber,
+};
+
+export const WHITELIST_PRIMITIVES_UTILS = {
+  stringify,
+  numericOnly,
+  padStartZeroes,
+};
+
+export const WHITELIST_ALL_UTILS = {
+  ...WHITELIST_LOCATION_TERMS_UTILS,
+  ...WHITELIST_PRIMITIVES_UTILS,
+};

--- a/src/__tests__/sellercloud/validators/index.ts
+++ b/src/__tests__/sellercloud/validators/index.ts
@@ -1,1 +1,2 @@
 export * from './primitives-only-validator';
+export * from './whitelists';

--- a/src/__tests__/sellercloud/validators/index.ts
+++ b/src/__tests__/sellercloud/validators/index.ts
@@ -1,0 +1,1 @@
+export * from './primitives-only-validator';

--- a/src/__tests__/sellercloud/validators/primitives-only-validator.ts
+++ b/src/__tests__/sellercloud/validators/primitives-only-validator.ts
@@ -1,0 +1,44 @@
+export const primitivesOnlyValidator =
+  <T>(context: T) =>
+  (input: string) =>
+  (strings: string[], ...args: (null | undefined | number | string | object | Function)[]) => {
+    // debugger;
+
+    // console.log('iterating');
+
+    let result = '';
+
+    strings.forEach((string, i) => {
+      const arg = args[i];
+
+      let value: number | string = '';
+
+      // Throw if `arg` is a complex object
+      if (typeof arg === 'object') {
+        throw new Error(
+          `Interpolated string expression appears to use an object argument value! Expected a primitive value such as a string or a number. Instead, got value: ${JSON.stringify(
+            arg,
+          )}`,
+        );
+      }
+
+      // Throw if `arg` is not a function of the form (context) => (input) => value
+      if (typeof arg === 'function') {
+        const withContext = arg(context);
+
+        if (typeof withContext !== 'function') {
+          throw new Error(
+            `Interpolated string expression appears to use a function argument incorrectly! Expected a function of the form (context) => (input) => value. Instead, got value: ${withContext}`,
+          );
+        }
+
+        value = withContext(input);
+      } else {
+        value = arg || '';
+      }
+
+      result += string + value;
+    });
+
+    return result;
+  };

--- a/src/__tests__/sellercloud/validators/whitelists.ts
+++ b/src/__tests__/sellercloud/validators/whitelists.ts
@@ -1,5 +1,3 @@
-import { levelNumber, rackNumber } from './rack';
-
 import { primitivesOnlyValidator } from './primitives-only-validator';
 
 export const WHITELIST_ALL_VALIDATORS = {

--- a/src/__tests__/sellercloud/validators/whitelists.ts
+++ b/src/__tests__/sellercloud/validators/whitelists.ts
@@ -1,0 +1,7 @@
+import { levelNumber, rackNumber } from './rack';
+
+import { primitivesOnlyValidator } from './primitives-only-validator';
+
+export const WHITELIST_ALL_VALIDATORS = {
+  primitivesOnlyValidator,
+};


### PR DESCRIPTION
- [x] Introduce `sellercloud.spec.ts` test suite with focus on tagged template literals (aka validator functions in the context of Skustack Lens)
- [x] Ensure positive and negative scenarios are introduced (e.g. against object or "invalid" function interpolation, or in favor of well-known `(context) => (input) => [eval]` function interpolation akin to `rackLevel` `numericOnly`, etc.)
- [ ] Introduce GitHub Actions with `npm install` `npm test` pipeline in order to ensure `js-sandbox` is stable, covering expected use cases
- [ ] Release internal package for use in Skustack Lens

<img width="396" alt="Screenshot 2024-09-08 at 11 56 12 AM" src="https://github.com/user-attachments/assets/551aaafe-fee7-4e68-a506-800ad91f7d5c">
